### PR TITLE
feat: add Laravel 12/13 compatibility, upgrade pest v2 → v3

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,13 +12,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        php: [8.3]
-        laravel: [11.*]
+        os: [ubuntu-latest]
+        php: [8.3, 8.4]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
+          - laravel: 12.*
+            testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         }
     ],
     "require": {
-        "php": "^8.1|^8.2|^8.3",
-        "illuminate/contracts": "^10.0|^11.0",
+        "php": "^8.1|^8.2|^8.3|^8.4",
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
         "maatwebsite/excel": "^3.1",
         "spatie/laravel-package-tools": "^1.9.2",
         "spatie/laravel-translatable": "^5.0|^6.0"
@@ -29,14 +29,14 @@
     "require-dev": {
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^8.0",
-        "larastan/larastan": "^2.9",
-        "orchestra/testbench": "^9.0",
-        "pestphp/pest": "^2.34",
-        "pestphp/pest-plugin-laravel": "^2.4",
-        "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan-deprecation-rules": "^1.2",
-        "phpstan/phpstan-phpunit": "^1.4",
-        "phpunit/phpunit": "^10.5"
+        "larastan/larastan": "^3.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^3.0",
+        "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+        "phpstan/extension-installer": "^1.4|^2.0",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpunit/phpunit": "^11.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Add illuminate/contracts ^12.0|^13.0 constraints
- Add PHP 8.4 support
- Upgrade pest ^2.34 → ^3.0, pest-plugin-laravel ^2.4 → ^3.0|^4.0
- Upgrade phpunit ^10.5 → ^11.0
- Upgrade larastan ^2.9 → ^3.0
- Upgrade phpstan-deprecation-rules ^1.2 → ^2.0, phpstan-phpunit ^1.4 → ^2.0
- Add orchestra/testbench ^10.0|^11.0 for Laravel 12/13
- Extend CI matrix to include Laravel 12.*/13.*, PHP 8.3/8.4

### Description


### Reason for this change